### PR TITLE
refactors: make writers and readers single-declaration

### DIFF
--- a/annotation/src/main/java/org/quiltmc/annotation_replacement/entry/AnnotationAddition.java
+++ b/annotation/src/main/java/org/quiltmc/annotation_replacement/entry/AnnotationAddition.java
@@ -30,7 +30,7 @@ import org.quiltmc.annotation_replacement.entry.value.LiteralAnnotationValue;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
 import org.quiltmc.mapping.parser.exception.IncorrectValueNameException;
 import org.quiltmc.mapping.parser.exception.IncorrectValueOrderException;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 public record AnnotationAddition(String descriptor, List<AnnotationValue> values)
 		implements MappingEntry<AnnotationAddition>, AnnotationInformation {
@@ -137,12 +137,12 @@ public record AnnotationAddition(String descriptor, List<AnnotationValue> values
 		return value;
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		writer.writeString("descriptor", this.descriptor);
 		writeValues(this.values, writer);
 	}
 
-	private void writeValues(List<AnnotationValue> values, QuiltMappingsWriter writer) {
+	private void writeValues(List<AnnotationValue> values, QuiltMappingWriter writer) {
 		writer.name("values");
 		writer.array(values, value -> writer.object(() -> {
 			writer.writeString("name", value.name());

--- a/annotation/src/main/java/org/quiltmc/annotation_replacement/entry/AnnotationModifications.java
+++ b/annotation/src/main/java/org/quiltmc/annotation_replacement/entry/AnnotationModifications.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.quiltmc.mapping.MappingType;
 import org.quiltmc.mapping.entry.MappingEntry;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 public record AnnotationModifications(List<AnnotationRemovalMapping> removals, List<AnnotationAddition> additions) implements MappingEntry<AnnotationModifications> {
 	public static final MappingType<AnnotationModifications> ANNOTATION_MODIFICATIONS_MAPPING_TYPE = new MappingType<>("annotation_modifications", MappingType.TokenType.OBJECT, AnnotationModifications.class, AnnotationModifications::parse, AnnotationModifications::write);
@@ -45,7 +45,7 @@ public record AnnotationModifications(List<AnnotationRemovalMapping> removals, L
 		return new AnnotationModifications(removals, additions);
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		List<MappingEntry<?>> children = new ArrayList<>();
 		children.addAll(this.additions);
 		children.addAll(this.removals);

--- a/annotation/src/main/java/org/quiltmc/annotation_replacement/entry/AnnotationRemovalMapping.java
+++ b/annotation/src/main/java/org/quiltmc/annotation_replacement/entry/AnnotationRemovalMapping.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.quiltmc.mapping.MappingType;
 import org.quiltmc.mapping.entry.MappingEntry;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 public record AnnotationRemovalMapping(
 		String descriptor) implements MappingEntry<AnnotationRemovalMapping> {
@@ -31,7 +31,7 @@ public record AnnotationRemovalMapping(
 		return new AnnotationRemovalMapping(parser.string());
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		writer.writeString(this.descriptor);
 	}
 

--- a/core/src/main/java/org/quiltmc/mapping/entry/info/ArgEntry.java
+++ b/core/src/main/java/org/quiltmc/mapping/entry/info/ArgEntry.java
@@ -25,7 +25,7 @@ import org.quiltmc.mapping.entry.AbstractParentMappingEntry;
 import org.quiltmc.mapping.entry.MappingEntry;
 import org.quiltmc.mapping.entry.naming.MethodEntry;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 public record ArgEntry(int index, @Nullable String name, List<MappingEntry<?>> children) implements MappingEntry<ArgEntry> {
 	public static final MappingType<ArgEntry> ARG_MAPPING_TYPE = new MappingType<>("args", MappingType.TokenType.OBJECT_ARRAY, ArgEntry.class, ArgEntry::parse, ArgEntry::write);
@@ -50,7 +50,7 @@ public record ArgEntry(int index, @Nullable String name, List<MappingEntry<?>> c
 		return new ArgEntry(index, argName, List.copyOf(children));
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		writer.writeInt("index", this.index);
 		if (this.name != null && !this.name.isEmpty()) {
 			writer.writeString("name", this.name);

--- a/core/src/main/java/org/quiltmc/mapping/entry/info/CommentEntry.java
+++ b/core/src/main/java/org/quiltmc/mapping/entry/info/CommentEntry.java
@@ -24,7 +24,7 @@ import org.quiltmc.mapping.entry.naming.ClassEntry;
 import org.quiltmc.mapping.entry.naming.FieldEntry;
 import org.quiltmc.mapping.entry.naming.MethodEntry;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 public record CommentEntry(String comment) implements MappingEntry<CommentEntry> {
 	public static final MappingType<CommentEntry> COMMENT_MAPPING_TYPE = new MappingType<>("comment", MappingType.TokenType.LITERAL, CommentEntry.class, CommentEntry::parse, CommentEntry::write);
@@ -33,7 +33,7 @@ public record CommentEntry(String comment) implements MappingEntry<CommentEntry>
 		return new CommentEntry(parser.string());
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		writer.writeString(this.comment);
 	}
 

--- a/core/src/main/java/org/quiltmc/mapping/entry/info/ReturnEntry.java
+++ b/core/src/main/java/org/quiltmc/mapping/entry/info/ReturnEntry.java
@@ -24,7 +24,7 @@ import org.quiltmc.mapping.entry.AbstractParentMappingEntry;
 import org.quiltmc.mapping.entry.MappingEntry;
 import org.quiltmc.mapping.entry.naming.MethodEntry;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 public record ReturnEntry(List<MappingEntry<?>> children) implements MappingEntry<ReturnEntry> {
 	public static final MappingType<ReturnEntry> RETURN_MAPPING_TYPE = new MappingType<>("return", MappingType.TokenType.OBJECT, ReturnEntry.class, ReturnEntry::parse, ReturnEntry::write);
@@ -40,7 +40,7 @@ public record ReturnEntry(List<MappingEntry<?>> children) implements MappingEntr
 		return new ReturnEntry(List.copyOf(children));
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		writer.writeChildren(this.children);
 	}
 

--- a/core/src/main/java/org/quiltmc/mapping/entry/naming/ClassEntry.java
+++ b/core/src/main/java/org/quiltmc/mapping/entry/naming/ClassEntry.java
@@ -24,7 +24,7 @@ import org.quiltmc.mapping.MappingType;
 import org.quiltmc.mapping.entry.AbstractParentMappingEntry;
 import org.quiltmc.mapping.entry.MappingEntry;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 public class ClassEntry extends AbstractParentMappingEntry<ClassEntry> {
 	public static final MappingType<ClassEntry> CLASS_MAPPING_TYPE = new MappingType<>("classes", MappingType.TokenType.OBJECT_ARRAY, ClassEntry.class, ClassEntry::parse, ClassEntry::write);
@@ -53,7 +53,7 @@ public class ClassEntry extends AbstractParentMappingEntry<ClassEntry> {
 		return new ClassEntry(fromName, toName, children);
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		writer.writeString("from_name", fromName);
 		if (this.toName != null && !this.toName.isEmpty()) {
 			writer.writeString("to_name", this.toName);

--- a/core/src/main/java/org/quiltmc/mapping/entry/naming/FieldEntry.java
+++ b/core/src/main/java/org/quiltmc/mapping/entry/naming/FieldEntry.java
@@ -24,7 +24,7 @@ import org.quiltmc.mapping.MappingType;
 import org.quiltmc.mapping.entry.AbstractParentDescriptorMappingEntry;
 import org.quiltmc.mapping.entry.MappingEntry;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 public class FieldEntry extends AbstractParentDescriptorMappingEntry<FieldEntry> {
 	public static final MappingType<FieldEntry> FIELD_MAPPING_TYPE = new MappingType<>("fields", MappingType.TokenType.OBJECT_ARRAY, FieldEntry.class, FieldEntry::parse, FieldEntry::write);
@@ -56,7 +56,7 @@ public class FieldEntry extends AbstractParentDescriptorMappingEntry<FieldEntry>
 		return new FieldEntry(fromName, toName, descriptor, children);
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		writer.writeString("from_name", fromName);
 		if (this.toName != null && !this.toName.isEmpty()) {
 			writer.writeString("to_name", this.toName);

--- a/core/src/main/java/org/quiltmc/mapping/entry/naming/MethodEntry.java
+++ b/core/src/main/java/org/quiltmc/mapping/entry/naming/MethodEntry.java
@@ -24,7 +24,7 @@ import org.quiltmc.mapping.MappingType;
 import org.quiltmc.mapping.entry.AbstractParentDescriptorMappingEntry;
 import org.quiltmc.mapping.entry.MappingEntry;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 public class MethodEntry extends AbstractParentDescriptorMappingEntry<MethodEntry> {
 	public static final MappingType<MethodEntry> METHOD_MAPPING_TYPE = new MappingType<>("methods", MappingType.TokenType.OBJECT_ARRAY, MethodEntry.class, MethodEntry::parse, MethodEntry::write);
@@ -56,7 +56,7 @@ public class MethodEntry extends AbstractParentDescriptorMappingEntry<MethodEntr
 		return new MethodEntry(fromName, toName, descriptor, children);
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		writer.writeString("from_name", fromName);
 		if (this.toName != null && !this.toName.isEmpty()) {
 			writer.writeString("to_name", this.toName);

--- a/core/src/main/java/org/quiltmc/mapping/entry/transitive/TransitiveEntry.java
+++ b/core/src/main/java/org/quiltmc/mapping/entry/transitive/TransitiveEntry.java
@@ -24,7 +24,7 @@ import org.quiltmc.mapping.entry.naming.ClassEntry;
 import org.quiltmc.mapping.entry.naming.FieldEntry;
 import org.quiltmc.mapping.entry.naming.MethodEntry;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 // TODO: Make this be able to select the transitive entries
 public record TransitiveEntry(String name) implements MappingEntry<TransitiveEntry> {
@@ -34,7 +34,7 @@ public record TransitiveEntry(String name) implements MappingEntry<TransitiveEnt
 		return new TransitiveEntry(parser.string());
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		writer.writeString(this.name);
 	}
 

--- a/core/src/main/java/org/quiltmc/mapping/entry/unpick/UnpickEntry.java
+++ b/core/src/main/java/org/quiltmc/mapping/entry/unpick/UnpickEntry.java
@@ -25,7 +25,7 @@ import org.quiltmc.mapping.entry.info.ArgEntry;
 import org.quiltmc.mapping.entry.info.ReturnEntry;
 import org.quiltmc.mapping.entry.naming.FieldEntry;
 import org.quiltmc.mapping.parser.QuiltMappingParser;
-import org.quiltmc.mapping.writer.QuiltMappingsWriter;
+import org.quiltmc.mapping.writer.QuiltMappingWriter;
 
 public record UnpickEntry(String group, @Nullable UnpickType type) implements MappingEntry<UnpickEntry> {
 	public static final MappingType<UnpickEntry> UNPICK_MAPPING_TYPE = new MappingType<>("unpick", MappingType.TokenType.OBJECT, UnpickEntry.class, UnpickEntry::parse, UnpickEntry::write);
@@ -48,7 +48,7 @@ public record UnpickEntry(String group, @Nullable UnpickType type) implements Ma
 		return new UnpickEntry(group, type);
 	}
 
-	public void write(QuiltMappingsWriter writer) {
+	public void write(QuiltMappingWriter writer) {
 		writer.writeString("group", this.group);
 		if (this.type != null) {
 			writer.writeEnum("type", this.type);

--- a/core/src/main/java/org/quiltmc/mapping/parser/QuiltMappingParser.java
+++ b/core/src/main/java/org/quiltmc/mapping/parser/QuiltMappingParser.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.Contract;
@@ -39,20 +40,19 @@ import org.quiltmc.mapping.parser.exception.MissingValueException;
 
 
 public class QuiltMappingParser {
-	public final Map<String, MappingType<?>> types;
-	private final String input;
+	private static final Logger LOGGER = Logger.getLogger("quilt mapping parser");
+	private final Map<String, MappingType<?>> types;
 
 	private final ThreadLocal<JsonReader> reader = new ThreadLocal<>();
 
-	public QuiltMappingParser(String input, Collection<MappingType<?>> types) {
-		this.input = input;
+	public QuiltMappingParser(Collection<MappingType<?>> types) {
 		this.types = types.stream().collect(Collectors.toMap(
 				MappingType::key,
 				Function.identity()
 		));
 	}
 
-	public QuiltMappingFile parse() {
+	public QuiltMappingFile parse(String input) {
 		JsonReader jsonReader = JsonReader.json5(input);
 		this.reader.set(jsonReader);
 
@@ -103,7 +103,7 @@ public class QuiltMappingParser {
 				children.add(parseMappingEntry(type));
 			}
 		} else {
-			System.out.println("unknown token: " + name);
+			LOGGER.warning("unknown token: " + name);
 			this.skip();
 		}
 	}

--- a/core/src/main/java/org/quiltmc/mapping/writer/MappingEntryWriter.java
+++ b/core/src/main/java/org/quiltmc/mapping/writer/MappingEntryWriter.java
@@ -19,5 +19,5 @@ package org.quiltmc.mapping.writer;
 import org.quiltmc.mapping.entry.MappingEntry;
 
 public interface MappingEntryWriter<T extends MappingEntry<T>> {
-	void write(T entry, QuiltMappingsWriter writer);
+	void write(T entry, QuiltMappingWriter writer);
 }

--- a/core/src/test/java/org/quiltmc/mapping/entry/MergeTest.java
+++ b/core/src/test/java/org/quiltmc/mapping/entry/MergeTest.java
@@ -17,6 +17,7 @@
 package org.quiltmc.mapping.entry;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -47,15 +48,23 @@ class MergeTest {
 
 	@Test
 	void testMergeFromFile() throws IOException {
-		String testMapping = new String(MergeTest.class.getClassLoader().getResourceAsStream("org/quiltmc/mapping/parser/TestMapping.quiltmapping").readAllBytes());
-		QuiltMappingFile testMappingFile = new QuiltMappingParser(testMapping, TYPES).parse();
+		QuiltMappingParser parser = new QuiltMappingParser(TYPES);
 
-		String testMappingSmall = new String(MergeTest.class.getClassLoader().getResourceAsStream("org/quiltmc/mapping/parser/TestMappingSmall.quiltmapping").readAllBytes());
-		QuiltMappingFile testMappingSmallFile = new QuiltMappingParser(testMappingSmall, TYPES).parse();
+		String testMapping = getInput("org/quiltmc/mapping/parser/TestMapping.quiltmapping");
+		QuiltMappingFile testMappingFile = parser.parse(testMapping);
 
-		String testMappingMerged = new String(MergeTest.class.getClassLoader().getResourceAsStream("org/quiltmc/mapping/parser/TestMappingMerged.quiltmapping").readAllBytes());
-		QuiltMappingFile testMappingMergedFile = new QuiltMappingParser(testMappingMerged, TYPES).parse();
+		String testMappingSmall = getInput("org/quiltmc/mapping/parser/TestMappingSmall.quiltmapping");
+		QuiltMappingFile testMappingSmallFile = parser.parse(testMappingSmall);
+
+		String testMappingMerged = getInput("org/quiltmc/mapping/parser/TestMappingMerged.quiltmapping");
+		QuiltMappingFile testMappingMergedFile = parser.parse(testMappingMerged);
 
 		assertEquals(testMappingMergedFile, testMappingFile.merge(testMappingSmallFile), "Merged correctly");
+	}
+
+	private String getInput(String name) throws IOException {
+		InputStream testMappingResource = MergeTest.class.getClassLoader().getResourceAsStream(name);
+		assert testMappingResource != null;
+		return new String(testMappingResource.readAllBytes());
 	}
 }

--- a/core/src/test/java/org/quiltmc/mapping/parser/QuiltMappingParserTest.java
+++ b/core/src/test/java/org/quiltmc/mapping/parser/QuiltMappingParserTest.java
@@ -46,33 +46,32 @@ class QuiltMappingParserTest {
 
 	@Test
 	void main() throws IOException {
+		QuiltMappingParser parser = new QuiltMappingParser(TYPES);
+
 		// test: test mapping file
 		// this test should parse as normal with no issues
 		String testMapping = getInput("org/quiltmc/mapping/parser/TestMapping.quiltmapping");
 		System.out.println("TestMapping.quiltmapping parsed output:");
-		System.out.println(new QuiltMappingParser(testMapping, TYPES).parse());
+		System.out.println(parser.parse(testMapping));
 
 		// test: test mapping file with negative argument index
 		String negativeArgIndexTest = getInput("org/quiltmc/mapping/parser/fail_cases/NegativeArgumentIndexTestMapping.quiltmapping");
-		QuiltMappingParser negativeArgParser = new QuiltMappingParser(negativeArgIndexTest, TYPES);
-		Assertions.assertThrows(ParsingException.class, negativeArgParser::parse);
+		Assertions.assertThrows(ParsingException.class, () -> parser.parse(negativeArgIndexTest));
 
 		// test: test mapping file with negative argument index
 		String nonexistentExtensionTest = getInput("org/quiltmc/mapping/parser/fail_cases/NonexistentExtensionTestMapping.quiltmapping");
-		QuiltMappingParser nonexistentExtensionParser = new QuiltMappingParser(nonexistentExtensionTest, TYPES);
-		Assertions.assertThrows(ParsingException.class, nonexistentExtensionParser::parse);
+		Assertions.assertThrows(ParsingException.class, () -> parser.parse(nonexistentExtensionTest));
 
 		// test: test mapping file with an incorrect value type
 		String incorrectValueTypeTest = getInput("org/quiltmc/mapping/parser/fail_cases/ExpectedIntegerTestMapping.quiltmapping");
-		QuiltMappingParser incorrectValueTypeParser = new QuiltMappingParser(incorrectValueTypeTest, TYPES);
-		Assertions.assertThrows(ParsingException.class, incorrectValueTypeParser::parse);
+		Assertions.assertThrows(ParsingException.class, () -> parser.parse(incorrectValueTypeTest));
 
 		// test: test mapping file with extra nonsense in it
 		// this test should pass and ignore the all the nonsense
 		// it should only print warnings
 		String badFormattingTestMapping = getInput("org/quiltmc/mapping/parser/BadlyFormattedTestMapping.quiltmapping");
 		System.out.println("BadlyFormattedTestMapping.quiltmapping parsed output:");
-		System.out.println(new QuiltMappingParser(badFormattingTestMapping, TYPES).parse());
+		System.out.println(parser.parse(badFormattingTestMapping));
 	}
 
 	private String getInput(String name) throws IOException {

--- a/core/src/test/java/org/quiltmc/mapping/writer/QuiltMappingWriterTest.java
+++ b/core/src/test/java/org/quiltmc/mapping/writer/QuiltMappingWriterTest.java
@@ -17,6 +17,7 @@
 package org.quiltmc.mapping.writer;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.List;
 
@@ -35,7 +36,7 @@ import org.quiltmc.mapping.parser.QuiltMappingParser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class QuiltMappingsWriterTest {
+class QuiltMappingWriterTest {
 	public static final List<MappingType<?>> TYPES = List.of(
 			ClassEntry.CLASS_MAPPING_TYPE,
 			MethodEntry.METHOD_MAPPING_TYPE,
@@ -49,13 +50,22 @@ class QuiltMappingsWriterTest {
 
 	@Test
 	void write() throws IOException {
-		String input = new String(QuiltMappingsWriterTest.class.getClassLoader().getResourceAsStream("org/quiltmc/mapping/parser/TestMapping.quiltmapping").readAllBytes());
-		QuiltMappingFile parsed = new QuiltMappingParser(input, TYPES).parse();
-		QuiltMappingsWriter writer = new QuiltMappingsWriter(parsed, TYPES);
-		StringWriter stringWriter = new StringWriter();
-		writer.write(stringWriter);
+		QuiltMappingParser parser = new QuiltMappingParser(TYPES);
 
-		QuiltMappingFile actual = new QuiltMappingParser(stringWriter.toString(), TYPES).parse();
+		String input = getInput("org/quiltmc/mapping/parser/TestMapping.quiltmapping");
+		QuiltMappingFile parsed = parser.parse(input);
+		QuiltMappingWriter writer = new QuiltMappingWriter(TYPES);
+		StringWriter stringWriter = new StringWriter();
+		writer.write(parsed, stringWriter);
+
+		QuiltMappingFile actual = parser.parse(stringWriter.toString());
 		assertEquals(parsed, actual, "Parses correctly");
+	}
+
+
+	private String getInput(String name) throws IOException {
+		InputStream testMappingResource = QuiltMappingWriterTest.class.getClassLoader().getResourceAsStream(name);
+		assert testMappingResource != null;
+		return new String(testMappingResource.readAllBytes());
 	}
 }

--- a/core/src/test/resources/org/quiltmc/mapping/parser/TestMappingMerged.quiltmapping
+++ b/core/src/test/resources/org/quiltmc/mapping/parser/TestMappingMerged.quiltmapping
@@ -40,6 +40,13 @@
               unpick: {
                 group: "<test_group>"
               }
+            },
+            {
+              index: 1,
+              name: "[name]",
+              unpick: {
+                group: "<test_group>"
+              }
             }
           ],
           return: {


### PR DESCRIPTION
this turned out to be a simpler change than I expected

- rename QuiltMappingsWriter to QuiltMappingWriter
- fix merged test (I broke it that was my fault)
- properly clear threadLocal after writing
- use a java logger instead of system.out to print warnings